### PR TITLE
Update buildsystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 .PHONY: format build clean rebuild open
+TEX := latexmk
+CONSTITUTION := ./constitution.tex
 
 format:
 	@echo -e "Formatting latex...\n"
@@ -7,18 +9,13 @@ format:
 build:
 	@echo -e "Building pdf...\n"
 	mkdir out
-	latexmk -output-directory=./out -pdf ./constitution.tex -shell-escape
-	@echo -e "\nNow just open ./out/constitution.pdf in your favorite pdf viewer!\n"
+	$(TEX) -output-directory=./out -pdf $(CONSTITUTION) -shell-escape -silent
+	@echo -e "PDF written to ./out/constitution.pdf\n"
 
 clean:
-	@echo -e "Deleting directories...\n"
-	-rm ./out/constitution.aux
-	-rm ./out/constitution.fdb_latexmk
-	-rm ./out/constitution.fls
-	-rm ./out/constitution.log
-	-rm ./out/constitution.out
-	-rm ./out/constitution.pdf
-	-rm ./out/constitution.toc
+	@echo -e "Deleting output files...\n"
+	$(TEX) -CA -output-directory=./out -silent
+	@echo -e "Deleting output directory...\n"
 	-rmdir ./out
 
 rebuild:

--- a/articles/article-09.tex
+++ b/articles/article-09.tex
@@ -1,1 +1,23 @@
 \article{Amendments}
+
+\asection{Update Buildsystem}
+\begin{enumerate}
+	\item Scope:
+		\begin{enumerate}
+			\item Makefile
+		\end{enumerate}
+
+	\item Description:
+		\begin{enumerate}
+			\item Update the Makefile to call alternate makefile flags.
+
+			\item Fix cleaning procedure to call latexmk-specific commands.
+		\end{enumerate}
+
+	\item Source:
+		\begin{enumerate}
+			\item Branch: Update Buildsystem
+
+			\item Pull-Request: TBD
+		\end{enumerate}
+\end{enumerate}


### PR DESCRIPTION
The makefile currently is a little jank, as it has some weird command-line arguments and is overall in need of fixing.

As a result, the following changes were made:
- There is now a "TEX" and "CONSTITUTION" variable to make it more
  obvious what we're building and where.
- Instead of manually deleting each file created by latexmk (which is
  subject to change), we instead call the "-CA" command-line flag to
  clean out all files created by latexmk.
- We now run the "-silent" flag on all latexmk invocations to clean up
  the crazy stdin. As far as I know, the "-quiet" flag is the same.

Possible other changes:
- We could also run "-c" as part of the building procedure to delete
  extra files on creation, though I don't think it hurts.