### PR TITLE
Allow for trivial changes

### DIFF
--- a/articles/article-08.tex
+++ b/articles/article-08.tex
@@ -6,7 +6,8 @@
 
 	\item Commit desired changes to personal fork.
 
-	\item Write short description of changes in \refarticle{Amendments}.
+	\item If the change is semantic and/or changes the meaning of the document,
+		you must include a one-sentence description in \refarticle{Amendments}.
 
 	\item Create a pull request on the main repository.
 

--- a/articles/article-08.tex
+++ b/articles/article-08.tex
@@ -7,7 +7,7 @@
 	\item Commit desired changes to personal fork.
 
 	\item If the change is semantic and/or changes the meaning of the document,
-		you must include a one-sentence description in \refarticle{Amendments}.
+		you must include a concise description of the changes in \refarticle{Amendments}.
 
 	\item Create a pull request on the main repository.
 

--- a/articles/article-09.tex
+++ b/articles/article-09.tex
@@ -1,1 +1,5 @@
 \article{Amendments}
+
+\begin{enumerate}
+	\item Allow for non-semantic and other trivial changes without listed amendments.
+\end{enumerate}


### PR DESCRIPTION
Currently it's quite onerous to require any and all changes to the constitution to require adding an amendment.

Simple stuff like formatting and build-system changes definitely should not need a description appended, and it will instead just clutter up the page.

I went with non-semantic changes as there's always some change that could be made of word choice, and as long as it doesn't change the meaning or interpretation of the document, it will be allowed.